### PR TITLE
Add a test for argument assertion using maps

### DIFF
--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -109,6 +109,15 @@ defmodule MockTest do
     end
   end
 
+  test "assert called with a map" do
+    with_mock(Map, [
+      get: fn (_map, _key) -> "a" end
+    ]) do
+      Map.get(%{a: "1", b: "2"}, :a)
+      assert_called(Map.get(%{a: "1"}, :a))
+    end
+  end
+
   test "assert_called_exactly" do
     with_mock String, [reverse: fn(x) -> 2*x end] do
       String.reverse(2)

--- a/test/mock_test.exs
+++ b/test/mock_test.exs
@@ -114,7 +114,7 @@ defmodule MockTest do
       get: fn (_map, _key) -> "a" end
     ]) do
       Map.get(%{a: "1", b: "2"}, :a)
-      assert_called(Map.get(%{a: "1"}, :a))
+      refute called(Map.get(%{a: "1"}, :a))
     end
   end
 


### PR DESCRIPTION
While using the `called` function with `Map` arguments I noticed that the matching was not exact, but that a map with different amount of key/values was still being mapped.

This PR adds a test to make sure that this is no longer the case and that assertion of a called function where an argument is a map is always against the same exact map.

The meck counterpart PR is: https://github.com/eproxus/meck/pull/244
Tests will not be green until this PR is merged and a meck version bump is made.